### PR TITLE
fix mountoptions don't allow blank space issue

### DIFF
--- a/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/blobfuse
+++ b/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/blobfuse
@@ -34,13 +34,13 @@ ismounted() {
 
 mount() {
 	MNTPATH="$1"
-	ACCOUNTNAME=$(echo "$2"|"$JQ" -r '.["kubernetes.io/secret/accountname"] // empty'|base64 -d)
-	ACCOUNTKEY=$(echo "$2"|"$JQ" -r '.["kubernetes.io/secret/accountkey"] // empty'|base64 -d)
-	CONTAINER=$(echo "$2"|"$JQ" -r '.container //empty')
-	TMP_PATH=$(echo "$2"|"$JQ" -r '.tmppath //empty')
-	MOUNT_OPTIONS=$(echo "$2"|"$JQ" -r '.mountoptions //empty')
-	READ_WRITE=$(echo "$2"|"$JQ" -r '.["kubernetes.io/readwrite"] //empty')
-	
+	ACCOUNTNAME=$(echo "$JSON"|"$JQ" -r '.["kubernetes.io/secret/accountname"] // empty'|base64 -d)
+	ACCOUNTKEY=$(echo "$JSON"|"$JQ" -r '.["kubernetes.io/secret/accountkey"] // empty'|base64 -d)
+	CONTAINER=$(echo "$JSON"|"$JQ" -r '.container //empty')
+	TMP_PATH=$(echo "$JSON"|"$JQ" -r '.tmppath //empty')
+	MOUNT_OPTIONS=$(echo "$JSON"|"$JQ" -r '.mountoptions //empty')
+	READ_WRITE=$(echo "$JSON"|"$JQ" -r '.["kubernetes.io/readwrite"] //empty')
+
 	if [ -z "${ACCOUNTNAME}" ]; then
 		err "{\"status\": \"Failure\", \"message\": \"validation failed, error log:accountname is empty\"}"
 		exit 1
@@ -144,6 +144,7 @@ shift
 
 case "$op" in
 	mount)
+		JSON=$2
 		mount $*
 		;;
 	unmount)

--- a/flexvolume/blobfuse/nginx-flex-blobfuse.yaml
+++ b/flexvolume/blobfuse/nginx-flex-blobfuse.yaml
@@ -19,4 +19,4 @@ spec:
       options:
         container: CONTAINER-NAME
         tmppath: /tmp/blobfuse
-        mountoptions: "--file-cache-timeout-in-seconds=120"
+        mountoptions: "--file-cache-timeout-in-seconds=120 --use-https=true"

--- a/flexvolume/blobfuse/pv-blobfuse-flexvol.yaml
+++ b/flexvolume/blobfuse/pv-blobfuse-flexvol.yaml
@@ -15,4 +15,4 @@ spec:
     options:
       container: CONTAINER-NAME
       tmppath: /tmp/blobfuse
-      mountoptions: "--file-cache-timeout-in-seconds=120"
+      mountoptions: "--file-cache-timeout-in-seconds=120 --use-https=true"


### PR DESCRIPTION
Just FYI. I fixed a common bug in blobfuse flexvol driver, e.g. If we specify `mountoptions: "--file-cache-timeout-in-seconds=120 --use-https=true"`, since there is a blank space there, flexvol driver could never parse that correctly and eventually mount failed, I fixed this issue by specify `JSON=$2` before exec `mount $*` in line#148

@ritazh @khenidak 