### PR TITLE
fix: invalid character s after object key:value pair

### DIFF
--- a/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/blobfuse
+++ b/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/blobfuse
@@ -4,7 +4,7 @@ DIR=$(dirname "$(readlink -f "$0")")
 JQ="/usr/bin/jq"
 BLOBFUSE="/usr/bin/blobfuse"
 LOG="/var/log/blobfuse-driver.log"
-VER="1.0.7"
+VER="1.0.8"
 
 usage() {
 	err "Invalid usage. Usage: "
@@ -89,8 +89,7 @@ mount() {
 		exit 1
 	fi
 
-	errorLog=`tail -n 1 "${LOG}"`
-	log "{\"status\": \"Success\" , \"message\":\"log:${errorLog}\" }"
+	log '{"status": "Success"}'
 	exit 0
 }
 

--- a/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/install.sh
+++ b/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 LOG="/var/log/blobfuse-flexvol-installer.log"
-VER="1.0.7"
+VER="1.0.8"
 target_dir="${TARGET_DIR}"
 
 if [[ -z "${target_dir}" ]]; then


### PR DESCRIPTION
This PR fixed following issue when mount two blobfuse volumes in parallel:
```
Events:
  Type     Reason       Age   From                               Message
  ----     ------       ----  ----                               -------
  Normal   Scheduled    29s   default-scheduler                  Successfully assigned default/nginx-flex-blobfuse2 to k8s-agentpool-34398540-1
  Warning  FailedMount  28s   kubelet, k8s-agentpool-34398540-1  MountVolume.SetUp failed for volume "test" : invalid character 's' after object key:value pair
  Normal   Pulling      23s   kubelet, k8s-agentpool-34398540-1  pulling image "nginx"
  Normal   Pulled       22s   kubelet, k8s-agentpool-34398540-1  Successfully pulled image "nginx"
  Normal   Created      22s   kubelet, k8s-agentpool-34398540-1  Created container
  Normal   Started      22s   kubelet, k8s-agentpool-34398540-1  Started container
```

example pod config could be like following:
```
apiVersion: v1
kind: Pod
metadata:
  name: nginx-flex-blobfuse
spec:
  containers:
  - name: nginx-flex-blobfuse
    image: nginx
    volumeMounts:
    - name: test
      mountPath: /data
    volumeMounts:
    - name: test2
      mountPath: /data2 
  volumes:
  - name: test
    flexVolume:
      driver: "azure/blobfuse"
      readOnly: false
      secretRef:
        name: blobfusecreds
      options:
        container: public
        tmppath: /tmp/blobfuse
        mountoptions: "--file-cache-timeout-in-seconds=120 --use-https=true"
  - name: test2
    flexVolume:
      driver: "azure/blobfuse"
      readOnly: false
      secretRef:
        name: blobfusecreds
      options:
        container: public2
        tmppath: /tmp/blobfuse
        mountoptions: "--file-cache-timeout-in-seconds=120 --use-https=true"		
```