### PR TITLE
run blobfuse in a transient systemd scope

### DIFF
--- a/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/blobfuse
+++ b/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/blobfuse
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 DIR=$(dirname "$(readlink -f "$0")")
 JQ="/usr/bin/jq"

--- a/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/blobfuse
+++ b/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/blobfuse
@@ -1,10 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 DIR=$(dirname "$(readlink -f "$0")")
 JQ="/usr/bin/jq"
 BLOBFUSE="blobfuse"
 LOG="/var/log/blobfuse-driver.log"
-VER="1.0.17"
+VER="1.0.18"
+SYSTEMD_RUN="/usr/bin/systemd-run"
 
 usage() {
 	err "Invalid usage. Usage: "
@@ -30,6 +31,18 @@ ismounted() {
 		return 0
 	fi
 	return 1
+}
+
+issystemdinstalled() {
+        if [ ! -f $SYSTEMD_RUN ]; then
+            return 1
+        fi
+        $SYSTEMD_RUN --scope -- true
+        if [ $? = 0 ]; then
+            return 0
+        else
+            return 1
+        fi
 }
 
 mount() {
@@ -103,8 +116,15 @@ mount() {
 	mkdir -p ${TMP_PATH}
 	
 	#mounting
-	echo "`date` EXEC: ${BLOBFUSE} ${MNTPATH} --container-name=${CONTAINER} --tmp-path=${TMP_PATH} -o allow_other ${read_only_param} ${MOUNT_OPTIONS}" >>$LOG
-	${BLOBFUSE} ${MNTPATH} --container-name=${CONTAINER} --tmp-path=${TMP_PATH} -o allow_other ${read_only_param} ${MOUNT_OPTIONS}
+        mount_cmd="${BLOBFUSE} ${MNTPATH} --container-name=${CONTAINER} --tmp-path=${TMP_PATH} -o allow_other ${read_only_param} ${MOUNT_OPTIONS}"
+        if issystemdinstalled ; then
+            echo "`date` EXEC: $SYSTEMD_RUN --scope -- $mount_cmd" >>$LOG
+            $SYSTEMD_RUN --scope -- $mount_cmd
+        else
+            echo "`date` EXEC: $mount_cmd" >>$LOG
+            $mount_cmd
+        fi
+
 	if [ "$?" != "0" ]; then
 		errorLog=`tail -n 1 "${LOG}"`
 		err "{ \"status\": \"Failure\", \"message\": \"Failed to mount device /dev/${diskname} at ${MNTPATH}, accountname:${ACCOUNTNAME}, error log:${errorLog}\" }"

--- a/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/install.sh
+++ b/flexvolume/blobfuse/deployment/blobfuse-flexvol-installer/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 LOG="/var/log/blobfuse-flexvol-installer.log"
-VER="1.0.17"
+VER="1.0.18"
 target_dir="${TARGET_DIR}"
 
 if [[ -z "${target_dir}" ]]; then


### PR DESCRIPTION
This PR is a bug fix.
The current azure blob volume starts the blob mount in  the same service unit of the kubelet.service .
"systemctl restart kubelet" will kill all processes in the  systemd's unit kubelet.service.  the blobfuse mount will lost the connection and never come back.
This change will try to run blobfuse mount in a systemd's transient scope. then the blobfuse processs will survive from the 
"systemctl restart kubelet"
