### PR TITLE
chore: use volueattachment for detach test and add portworx cyc test.

### DIFF
--- a/test/attach_detach_test_v2.sh
+++ b/test/attach_detach_test_v2.sh
@@ -1,5 +1,5 @@
-# use sh attach_detach_test.sh 500 default file.txt to test 500 pods with default sc and write results in file.txt.
-# attach_detach_test.sh use pod in running state for attach test and pv deletion for detach test.
+# use sh attach_detach_test_v2.sh 500 default file.txt to test 500 pods with default sc and write results in file.txt.
+# attach_detach_test_v2.sh use pod in running state for attach test and volumeattachments in false for detach test.
 kubectl create ns test
 predate=$(date +"%Y-%m-%d %H:%M:%S")
 pvcflag=0
@@ -157,26 +157,26 @@ spec:
             storage: 1Gi
 EOF
 kubectl delete pvc -n test --all &
-detachnum=$(kubectl get pv | grep pvc- | awk 'END{print NR}')
+detachnum=$(kubectl get volumeattachments -n test | grep true | grep pvc- | awk 'END{print NR}')
 while [ $detachnum -ge $((p100-p50+1)) ]
 do
 sleep 1
 date1=$(date +"%Y-%m-%d %H:%M:%S")
-detachnum=$(kubectl get pv | grep pvc- | awk 'END{print NR}')
+detachnum=$(kubectl get volumeattachments -n test | grep true | grep pvc- | awk 'END{print NR}')
 done
 echo "detach p50: $(( $(date -d "$date1" "+%s") - $(date -d "$predate" "+%s") ))" >> $3
 while [ $detachnum -ge $((p100-p90+1)) ]
 do
 sleep 1
 date1=$(date +"%Y-%m-%d %H:%M:%S")
-detachnum=$(kubectl get pv | grep pvc- | awk 'END{print NR}')
+detachnum=$(kubectl get volumeattachments -n test | grep true | grep pvc- | awk 'END{print NR}')
 done
 echo "detach p90: $(( $(date -d "$date1" "+%s") - $(date -d "$predate" "+%s") ))" >> $3
 while [ $detachnum -ge $((p100-p99+1)) ]
 do
 sleep 1
 date1=$(date +"%Y-%m-%d %H:%M:%S")
-detachnum=$(kubectl get pv | grep pvc- | awk 'END{print NR}')
+detachnum=$(kubectl get volumeattachments -n test | grep true | grep pvc- | awk 'END{print NR}')
 done
 echo "detach p99: $(( $(date -d "$date1" "+%s") - $(date -d "$predate" "+%s") ))" >> $3
 kubectl delete ns test

--- a/test/cyc_attach_detach_test.sh
+++ b/test/cyc_attach_detach_test.sh
@@ -3,7 +3,7 @@
 for i in $(seq $4)
 do
     echo "`date` test $i" >> $3
-    curl -skSL https://raw.githubusercontent.com/Azure/kubernetes-volume-drivers/master/test/attach_detach_test.sh | bash -s $1 $2 $3 --
+    curl -skSL https://raw.githubusercontent.com/Azure/kubernetes-volume-drivers/master/test/attach_detach_test_v2.sh | bash -s $1 $2 $3 --
     echo "sleep 10 minutes ..." >> $3
     sleep 10m
 done

--- a/test/cyc_attach_detach_test_portworx.sh
+++ b/test/cyc_attach_detach_test_portworx.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for i in $(seq $4)
+do
+    echo "`date` test $i" >> $3
+    curl -skSL https://raw.githubusercontent.com/Azure/kubernetes-volume-drivers/master/test/attach_detach_test.sh | bash -s $1 $2 $3 --
+    echo "sleep 10 minutes ..." >> $3
+    sleep 10m
+done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup

**What this PR does / why we need it**:
use volueattachment for detach test and improve script.
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Because portworx only use mount, so pv deletion is used for portworx detach test. For other CSI, we use volumeattachments for detach test in attach_detach_test_v2.sh

**Release note**:
```
none
```
